### PR TITLE
Feat: 테스트 커버리지 개선, ReviewRepositoryTest 주석 해제 외

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,2 @@
+config.stopBubbling = true
+lombok.addLombokGeneratedAnnotation = true

--- a/src/main/java/com/sprint/sb06deokhugamteam01/exception/comment/CommentAccessDeniedException.java
+++ b/src/main/java/com/sprint/sb06deokhugamteam01/exception/comment/CommentAccessDeniedException.java
@@ -6,9 +6,6 @@ import com.sprint.sb06deokhugamteam01.exception.RootException;
 import java.util.Map;
 
 public class CommentAccessDeniedException extends RootException {
-    public CommentAccessDeniedException() {
-        super(ErrorCode.COMMENT_ACCESS_DENIED);
-    }
     public CommentAccessDeniedException(Map<String, Object> details) {
         super(ErrorCode.COMMENT_ACCESS_DENIED, details);
     }

--- a/src/main/java/com/sprint/sb06deokhugamteam01/exception/comment/CommentNotFoundException.java
+++ b/src/main/java/com/sprint/sb06deokhugamteam01/exception/comment/CommentNotFoundException.java
@@ -6,9 +6,6 @@ import com.sprint.sb06deokhugamteam01.exception.RootException;
 import java.util.Map;
 
 public class CommentNotFoundException extends RootException {
-    public CommentNotFoundException() {
-        super(ErrorCode.COMMENT_NOT_FOUND);
-    }
     public CommentNotFoundException(Map<String, Object> details) {
         super(ErrorCode.COMMENT_NOT_FOUND, details);
     }

--- a/src/test/java/com/sprint/sb06deokhugamteam01/dto/DtoTest.java
+++ b/src/test/java/com/sprint/sb06deokhugamteam01/dto/DtoTest.java
@@ -5,9 +5,13 @@ import com.sprint.sb06deokhugamteam01.domain.batch.BatchBookRating;
 import com.sprint.sb06deokhugamteam01.domain.batch.BatchUserRating;
 import com.sprint.sb06deokhugamteam01.domain.batch.PeriodType;
 import com.sprint.sb06deokhugamteam01.domain.book.Book;
+import com.sprint.sb06deokhugamteam01.dto.User.request.PowerUserRequest;
 import com.sprint.sb06deokhugamteam01.dto.User.response.CursorPageResponsePowerUserDto;
 import com.sprint.sb06deokhugamteam01.dto.User.response.PowerUserDto;
 import com.sprint.sb06deokhugamteam01.dto.book.PopularBookDto;
+import com.sprint.sb06deokhugamteam01.dto.book.naver.BookData;
+import com.sprint.sb06deokhugamteam01.dto.book.naver.NaverBookSearchResponse;
+import com.sprint.sb06deokhugamteam01.dto.notification.PageNotificationRequest;
 import com.sprint.sb06deokhugamteam01.exception.ErrorCode;
 import com.sprint.sb06deokhugamteam01.exception.RootException;
 import org.junit.jupiter.api.DisplayName;
@@ -111,5 +115,62 @@ public class DtoTest {
         );
 
         assertThat(dto.totalElements()).isEqualTo(100);
+    }
+
+    @Test
+    @DisplayName("BookData 테스트")
+    void BookDataTest() {
+        // given & when
+        BookData bookData = new BookData("책", "link", "image", "저자",
+                "discount", "publisher", "20251210", "isbn", "description");
+
+        // then
+        assertThat(bookData.getPublishedDate()).isEqualTo(LocalDate.of(2025, 12, 10));
+    }
+    @Test
+    @DisplayName("BookData 테스트 - invalid pubdate")
+    void BookDataTest_InvalidPubdate() {
+        // given & when
+        BookData bookData = new BookData("책", "link", "image", "저자",
+                "discount", "publisher", "222", "isbn", "description");
+
+        // then
+        assertThat(bookData.getPublishedDate()).isNull();
+    }
+    @Test
+    @DisplayName("NaverBookSearchResponse 테스트")
+    void NaverBookSearchResponseTest() {
+        // given & when
+        NaverBookSearchResponse response = new NaverBookSearchResponse(
+                "20220202", 10, 10, 10, new BookData[]{}
+        );
+
+        // then
+        assertThat(response.items()).isEmpty();
+    }
+    @Test
+    @DisplayName("PageNotificationRequest 테스트")
+    void PageNotificationRequestTest() {
+        // given & when
+        PageNotificationRequest request = new PageNotificationRequest(
+                UUID.randomUUID(), "ASC", "cursor", LocalDateTime.now(), 10
+        );
+
+        // then
+        assertThat(request.isAscending()).isTrue();
+    }
+    @Test
+    @DisplayName("PowerUserRequest 테스트")
+    void PowerUserRequestTest() {
+        // given & when
+        LocalDateTime time = LocalDateTime.now();
+        PowerUserRequest request = new PowerUserRequest(
+                "monthly", "ASC", "cursor", time, 10
+        );
+        request.toPeriodType();
+        request.setPeriodStart(LocalDate.now());
+
+        // then
+        assertThat(request.after()).isEqualTo(time);
     }
 }

--- a/src/test/java/com/sprint/sb06deokhugamteam01/dto/DtoTest.java
+++ b/src/test/java/com/sprint/sb06deokhugamteam01/dto/DtoTest.java
@@ -1,0 +1,115 @@
+package com.sprint.sb06deokhugamteam01.dto;
+
+import com.sprint.sb06deokhugamteam01.domain.User;
+import com.sprint.sb06deokhugamteam01.domain.batch.BatchBookRating;
+import com.sprint.sb06deokhugamteam01.domain.batch.BatchUserRating;
+import com.sprint.sb06deokhugamteam01.domain.batch.PeriodType;
+import com.sprint.sb06deokhugamteam01.domain.book.Book;
+import com.sprint.sb06deokhugamteam01.dto.User.response.CursorPageResponsePowerUserDto;
+import com.sprint.sb06deokhugamteam01.dto.User.response.PowerUserDto;
+import com.sprint.sb06deokhugamteam01.dto.book.PopularBookDto;
+import com.sprint.sb06deokhugamteam01.exception.ErrorCode;
+import com.sprint.sb06deokhugamteam01.exception.RootException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DtoTest {
+    @Test
+    @DisplayName("ErrorDto 테스트 - RootException")
+    void errorDtoTest_RootException() {
+        // given
+        ErrorCode errorCode = ErrorCode.INTERNAL_SERVER_ERROR;
+        RootException e = new RootException(errorCode, Map.of());
+
+        // when
+        ResponseEntity<ErrorDto> result = ErrorDto.toResponseEntity(e);
+
+        // then
+        assertThat(result.getBody().status()).isEqualTo(errorCode.getStatus());
+    }
+    @Test
+    @DisplayName("ErrorDto 테스트 - Exception")
+    void errorDtoTest_Exception() {
+        // given
+        Exception e = new Exception();
+
+        // when
+        ResponseEntity<ErrorDto> result = ErrorDto.toResponseEntity(e);
+
+        // then
+        assertThat(result.getBody().status()).isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR.value());
+    }
+    @Test
+    @DisplayName("PopularBookDto 테스트")
+    void bookDtoTest_BookDto() {
+        // given
+        Book book = Book.builder().title("책").author("저자").description("설명")
+                .publishedDate(LocalDate.now()).publisher("출판사").isbn("123").build();
+        book.updateThumbnailUrl("url");
+        ReflectionTestUtils.setField(book, "id", UUID.randomUUID());
+        BatchBookRating batchBookRating = BatchBookRating.builder().id(UUID.randomUUID())
+                .periodType(PeriodType.DAILY).rank(1).score(1).createdAt(LocalDateTime.now()).build();
+
+        //when
+        PopularBookDto result = PopularBookDto.fromEntity(book, batchBookRating);
+
+        // then
+        assertThat(result.author()).isEqualTo("저자");
+        assertThat(result.rank()).isEqualTo(1L);
+    }
+    @Test
+    @DisplayName("PopularBookDto 테스트 - String 파라미터 포함")
+    void bookDtoTest_BookDto_WithString() {
+        // given
+        Book book = Book.builder().title("책").author("저자").description("설명")
+                .publishedDate(LocalDate.now()).publisher("출판사").isbn("123").build();
+        book.updateThumbnailUrl("url");
+        ReflectionTestUtils.setField(book, "id", UUID.randomUUID());
+        BatchBookRating batchBookRating = BatchBookRating.builder().id(UUID.randomUUID())
+                .periodType(PeriodType.DAILY).rank(1).score(1).createdAt(LocalDateTime.now()).build();
+        String imageUrl = "url";
+
+        //when
+        PopularBookDto result = PopularBookDto.fromEntityWithImageUrl(book, batchBookRating, imageUrl);
+
+        // then
+        assertThat(result.author()).isEqualTo("저자");
+        assertThat(result.thumbnailUrl()).isEqualTo(imageUrl);
+    }
+    @Test
+    @DisplayName("PowerUserDto 테스트")
+    void powerUserDtoTest() {
+        // given
+        User user = User.builder().id(UUID.randomUUID()).nickname("유저").build();
+        BatchUserRating rating = BatchUserRating.builder().user(user)
+                .periodType(PeriodType.DAILY).createdAt(LocalDateTime.now())
+                .rank(1).score(1).reviewPopularitySum(1).likesMade(1).commentsMade(1).build();
+
+        // when
+        PowerUserDto dto = PowerUserDto.fromBatchUserRating(rating);
+
+        // then
+        assertThat(dto.nickname()).isEqualTo(user.getNickname());
+        assertThat(dto.rank()).isEqualTo(1L);
+    }
+    @Test
+    @DisplayName("CursorPageResponsePowerUserDto 테스트")
+    void cursorPageResponsePowerUserDtoTest() {
+        CursorPageResponsePowerUserDto dto = new CursorPageResponsePowerUserDto(
+                List.of(), "nextCursor", "nextAfter", 3, 100, true
+        );
+
+        assertThat(dto.totalElements()).isEqualTo(100);
+    }
+}

--- a/src/test/java/com/sprint/sb06deokhugamteam01/exception/GlobalExceptionTest.java
+++ b/src/test/java/com/sprint/sb06deokhugamteam01/exception/GlobalExceptionTest.java
@@ -1,0 +1,102 @@
+package com.sprint.sb06deokhugamteam01.exception;
+
+import com.sprint.sb06deokhugamteam01.exception.book.*;
+import com.sprint.sb06deokhugamteam01.exception.common.InvalidException;
+import com.sprint.sb06deokhugamteam01.exception.review.ReviewAlreadyExistsException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GlobalExceptionTest {
+
+    @Test
+    @DisplayName("OcrProcessingException 생성 테스트")
+    void ocrProcessingException() {
+        // given & when
+        OcrProcessingException e = new OcrProcessingException(Map.of("message", "details"));
+
+        // then
+        assertThat(e.getErrorCode()).isEqualTo(ErrorCode.OCR_PROCESSING_FAILED);
+        assertThat(e.getMessage()).isEqualTo("OCR processing failed");
+    }
+
+    @Test
+    @DisplayName("BookInfoFetchFailedException 생성 테스트")
+    void bookInfoFetchFailedException() {
+        // given & when
+        BookInfoFetchFailedException e = new  BookInfoFetchFailedException(Map.of("isbn", "details"));
+
+        // then
+        assertThat(e.getErrorCode()).isEqualTo(ErrorCode.BOOK_INFO_FETCH_FAILED);
+        assertThat(e.getMessage()).isEqualTo("Book info fetch failed");
+    }
+
+    @Test
+    @DisplayName("S3ObjectNotFoundException 생성 테스트")
+    void s3ObjectNotFoundException() {
+        // given & when
+        S3ObjectNotFound e = new S3ObjectNotFound(Map.of("id", 1L));
+
+        // then
+        assertThat(e.getErrorCode()).isEqualTo(ErrorCode.S3_OBJECT_NOT_FOUND);
+        assertThat(e.getMessage()).isEqualTo("S3 object not found");
+    }
+
+    @Test
+    @DisplayName("InvalidIsbnException 생성 테스트")
+    void invalidIsbnException() {
+        // given & when
+        InvalidIsbnException e = new InvalidIsbnException(Map.of());
+
+        // then
+        assertThat(e.getErrorCode()).isEqualTo(ErrorCode.INVALID_ISBN);
+        assertThat(e.getMessage()).isEqualTo("Invalid ISBN");
+    }
+
+    @Test
+    @DisplayName("S3DeleteFailedException 생성 테스트")
+    void  s3DeleteFailedException() {
+        // given & when
+        S3DeleteFailedException e = new  S3DeleteFailedException(Map.of("id", 1L));
+
+        // then
+        assertThat(e.getErrorCode()).isEqualTo(ErrorCode.S3_DELETE_FAILED);
+        assertThat(e.getMessage()).isEqualTo("S3 delete failed");
+    }
+
+    @Test
+    @DisplayName("InvalidException 생성 테스트")
+    void invalidException() {
+        // given & when
+        InvalidException e = new InvalidException(Map.of());
+
+        // then
+        assertThat(e.getErrorCode()).isEqualTo(ErrorCode.INVALID_REQUEST);
+        assertThat(e.getMessage()).isEqualTo("Invalid request");
+    }
+
+    @Test
+    @DisplayName("RootException 생성 테스트 - 파라미터 ErrorCode")
+    void rootException() {
+        // given & when
+        RootException e = new RootException(ErrorCode.INTERNAL_SERVER_ERROR);
+        e.addDetail("details", "details");
+
+        // then
+        assertThat(e.getErrorCode()).isEqualTo(ErrorCode.INTERNAL_SERVER_ERROR);
+    }
+
+    @Test
+    @DisplayName("ReviewAlreadyExistsException 생성 테스트")
+    void  reviewAlreadyExistsException() {
+        // given & when
+        ReviewAlreadyExistsException e = new ReviewAlreadyExistsException(Map.of("cursor", "cursor"));
+
+        // then
+        assertThat(e.getErrorCode()).isEqualTo(ErrorCode.REVIEW_ALREADY_EXISTS);
+        assertThat(e.getMessage()).isEqualTo("Review already exists");
+    }
+}

--- a/src/test/java/com/sprint/sb06deokhugamteam01/exception/GlobalExceptionTest.java
+++ b/src/test/java/com/sprint/sb06deokhugamteam01/exception/GlobalExceptionTest.java
@@ -20,7 +20,6 @@ public class GlobalExceptionTest {
 
         // then
         assertThat(e.getErrorCode()).isEqualTo(ErrorCode.OCR_PROCESSING_FAILED);
-        assertThat(e.getMessage()).isEqualTo("OCR processing failed");
     }
 
     @Test
@@ -31,7 +30,6 @@ public class GlobalExceptionTest {
 
         // then
         assertThat(e.getErrorCode()).isEqualTo(ErrorCode.BOOK_INFO_FETCH_FAILED);
-        assertThat(e.getMessage()).isEqualTo("Book info fetch failed");
     }
 
     @Test
@@ -42,7 +40,6 @@ public class GlobalExceptionTest {
 
         // then
         assertThat(e.getErrorCode()).isEqualTo(ErrorCode.S3_OBJECT_NOT_FOUND);
-        assertThat(e.getMessage()).isEqualTo("S3 object not found");
     }
 
     @Test
@@ -53,7 +50,6 @@ public class GlobalExceptionTest {
 
         // then
         assertThat(e.getErrorCode()).isEqualTo(ErrorCode.INVALID_ISBN);
-        assertThat(e.getMessage()).isEqualTo("Invalid ISBN");
     }
 
     @Test
@@ -64,7 +60,6 @@ public class GlobalExceptionTest {
 
         // then
         assertThat(e.getErrorCode()).isEqualTo(ErrorCode.S3_DELETE_FAILED);
-        assertThat(e.getMessage()).isEqualTo("S3 delete failed");
     }
 
     @Test
@@ -75,7 +70,6 @@ public class GlobalExceptionTest {
 
         // then
         assertThat(e.getErrorCode()).isEqualTo(ErrorCode.INVALID_REQUEST);
-        assertThat(e.getMessage()).isEqualTo("Invalid request");
     }
 
     @Test
@@ -97,6 +91,5 @@ public class GlobalExceptionTest {
 
         // then
         assertThat(e.getErrorCode()).isEqualTo(ErrorCode.REVIEW_ALREADY_EXISTS);
-        assertThat(e.getMessage()).isEqualTo("Review already exists");
     }
 }

--- a/src/test/java/com/sprint/sb06deokhugamteam01/mapper/MapperTest.java
+++ b/src/test/java/com/sprint/sb06deokhugamteam01/mapper/MapperTest.java
@@ -1,0 +1,59 @@
+package com.sprint.sb06deokhugamteam01.mapper;
+
+import com.sprint.sb06deokhugamteam01.domain.Review;
+import com.sprint.sb06deokhugamteam01.domain.User;
+import com.sprint.sb06deokhugamteam01.dto.review.response.ReviewDto;
+import com.sprint.sb06deokhugamteam01.repository.review.ReviewLikeRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+public class MapperTest {
+    @Mock
+    private ReviewLikeRepository reviewLikeRepository;
+
+    @InjectMocks
+    private ReviewMapper reviewMapper;
+
+    @Test
+    @DisplayName("Review 엔티티 -> DTO 변환 테스트 (Review, User)")
+    void toDto_Single() {
+        // given
+        User user = User.builder().id(UUID.randomUUID()).nickname("유저").build();
+        Review review = Review.builder().id(UUID.randomUUID())
+                .content("좋은 책입니다. 추천합니다.").user(user).build();
+        given(reviewLikeRepository.existsByUserAndReview(any(), any())).willReturn(true);
+
+        // when
+        ReviewDto dto = reviewMapper.toDto(review, user);
+
+        // then
+        assertThat(dto.content()).isEqualTo(review.getContent());
+        assertThat(dto.likedByMe()).isTrue();
+    }
+
+    @Test
+    @DisplayName("Review 엔티티 -> DTO 변환 테스트 (Review, boolean)")
+    void toDto_Bulk() {
+        // given
+        Review review = Review.builder().id(UUID.randomUUID())
+                .content("좋은 책입니다. 추천합니다.").build();
+        boolean isLiked = false;
+
+        // when
+        ReviewDto dto = reviewMapper.toDto(review, isLiked);
+
+        // then
+        assertThat(dto.content()).isEqualTo(review.getContent());
+        assertThat(dto.likedByMe()).isFalse();
+    }
+}

--- a/src/test/java/com/sprint/sb06deokhugamteam01/mapper/MapperTest.java
+++ b/src/test/java/com/sprint/sb06deokhugamteam01/mapper/MapperTest.java
@@ -31,10 +31,11 @@ public class MapperTest {
         User user = User.builder().id(UUID.randomUUID()).nickname("유저").build();
         Review review = Review.builder().id(UUID.randomUUID())
                 .content("좋은 책입니다. 추천합니다.").user(user).build();
+        String imageUrl = "url";
         given(reviewLikeRepository.existsByUserAndReview(any(), any())).willReturn(true);
 
         // when
-        ReviewDto dto = reviewMapper.toDto(review, user);
+        ReviewDto dto = reviewMapper.toDto(review, user, imageUrl);
 
         // then
         assertThat(dto.content()).isEqualTo(review.getContent());
@@ -47,10 +48,11 @@ public class MapperTest {
         // given
         Review review = Review.builder().id(UUID.randomUUID())
                 .content("좋은 책입니다. 추천합니다.").build();
+        String imageUrl = "url";
         boolean isLiked = false;
 
         // when
-        ReviewDto dto = reviewMapper.toDto(review, isLiked);
+        ReviewDto dto = reviewMapper.toDto(review, isLiked, imageUrl);
 
         // then
         assertThat(dto.content()).isEqualTo(review.getContent());

--- a/src/test/java/com/sprint/sb06deokhugamteam01/repository/BatchUserRatingRepositoryTest.java
+++ b/src/test/java/com/sprint/sb06deokhugamteam01/repository/BatchUserRatingRepositoryTest.java
@@ -1,0 +1,5 @@
+package com.sprint.sb06deokhugamteam01.repository;
+
+
+public class BatchUserRatingRepositoryTest {
+}

--- a/src/test/java/com/sprint/sb06deokhugamteam01/repository/NotificationRepositoryTest.java
+++ b/src/test/java/com/sprint/sb06deokhugamteam01/repository/NotificationRepositoryTest.java
@@ -2,7 +2,6 @@ package com.sprint.sb06deokhugamteam01.repository;
 
 import com.sprint.sb06deokhugamteam01.config.QueryDslConfig;
 import com.sprint.sb06deokhugamteam01.domain.Notification;
-import com.sprint.sb06deokhugamteam01.domain.Review;
 import com.sprint.sb06deokhugamteam01.domain.User;
 import com.sprint.sb06deokhugamteam01.repository.notification.NotificationRepository;
 import jakarta.persistence.EntityManager;
@@ -13,11 +12,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
 import java.util.UUID;

--- a/src/test/java/com/sprint/sb06deokhugamteam01/repository/NotificationRepositoryTest.java
+++ b/src/test/java/com/sprint/sb06deokhugamteam01/repository/NotificationRepositoryTest.java
@@ -1,0 +1,81 @@
+package com.sprint.sb06deokhugamteam01.repository;
+
+import com.sprint.sb06deokhugamteam01.config.QueryDslConfig;
+import com.sprint.sb06deokhugamteam01.domain.Notification;
+import com.sprint.sb06deokhugamteam01.domain.Review;
+import com.sprint.sb06deokhugamteam01.domain.User;
+import com.sprint.sb06deokhugamteam01.repository.notification.NotificationRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest(includeFilters = @ComponentScan.Filter(
+        type = FilterType.ASSIGNABLE_TYPE,
+        classes = {
+                NotificationRepository.class, QueryDslConfig.class
+        }
+))
+@ActiveProfiles("test")
+public class NotificationRepositoryTest {
+    @Autowired
+    private NotificationRepository notificationRepository;
+    @Autowired
+    private EntityManager em;
+
+
+    private void forceUpdateCreatedAt(UUID id, LocalDateTime time){
+        Query query = em.createNativeQuery("UPDATE notification SET created_at=?1 WHERE id=?2");
+        query.setParameter(1, time);
+        query.setParameter(2, id);
+        query.executeUpdate();
+    }
+
+    @Test
+    @DisplayName("getNotifications 성공")
+    void getNotifications_Success() {
+        // given
+        User user = User.builder().build();
+        em.persist(user);
+        LocalDateTime time = LocalDateTime.now();
+        boolean ascending = true;
+        Integer limit = 10;
+        Pageable pageable = null;
+
+        Notification notification = notificationRepository.save(new Notification(null, "content", false,
+                null, null, user, null));
+        forceUpdateCreatedAt(notification.getId(), time);
+        Notification notification2 = notificationRepository.save(new Notification(null, "content", true,
+                null, null, user, null));
+        forceUpdateCreatedAt(notification2.getId(), time.minusDays(1));
+        Notification notification3 = notificationRepository.save(new Notification(null, "content", true,
+                null, null, user, null));
+        forceUpdateCreatedAt(notification3.getId(), time.minusDays(2));
+        em.refresh(notification);
+        em.refresh(notification2);
+        em.refresh(notification3);
+
+        // when
+        Slice<Notification> result = notificationRepository.getNotifications(user.getId(), notification2.getId().toString(),
+                notification2.getCreatedAt(), ascending, limit, pageable);
+
+        // then
+        assertThat(notificationRepository.count()).isEqualTo(3);
+        assertThat(result).hasSize(1);
+        assertThat(result).extracting(Notification::getId).containsExactly(notification.getId());
+    }
+}

--- a/src/test/java/com/sprint/sb06deokhugamteam01/repository/ReviewRepositoryTest.java
+++ b/src/test/java/com/sprint/sb06deokhugamteam01/repository/ReviewRepositoryTest.java
@@ -10,6 +10,7 @@ import com.sprint.sb06deokhugamteam01.domain.Review;
 import com.sprint.sb06deokhugamteam01.dto.review.ReviewSearchCondition;
 import com.sprint.sb06deokhugamteam01.repository.review.ReviewRepository;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -21,6 +22,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -36,7 +38,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @ActiveProfiles("test")
 class ReviewRepositoryTest {
 
-    /*@Autowired
+    @Autowired
     private ReviewRepository reviewRepository;
 
     @Autowired
@@ -104,6 +106,7 @@ class ReviewRepositoryTest {
                 .build();
         testBook2 = em.merge(testBook2);
 
+        LocalDateTime time = LocalDateTime.now().minusDays(4);
         testReview1 = Review.builder()
                 .rating(5)
                 .likeCount(50)
@@ -112,10 +115,12 @@ class ReviewRepositoryTest {
                 .user(testUser1)
                 .book(testBook1)
                 .content("Review 1 content")
-                .createdAt(LocalDateTime.now().minusDays(4))
+                .createdAt(time)
                 .build();
         testReview1 = em.merge(testReview1);
+        forceUpdateCreatedAt(testReview1, time);
 
+        LocalDateTime time2 = LocalDateTime.now().minusDays(3);
         testReview2 = Review.builder()
                 .rating(4)
                 .likeCount(40)
@@ -124,10 +129,12 @@ class ReviewRepositoryTest {
                 .user(testUser1)
                 .book(testBook2)
                 .content("Review 2 content")
-                .createdAt(LocalDateTime.now().minusDays(3))
+                .createdAt(time2)
                 .build();
         testReview2 = em.merge(testReview2);
+        forceUpdateCreatedAt(testReview2, time2);
 
+        LocalDateTime time3 = LocalDateTime.now().minusDays(2);
         testReview3 = Review.builder()
                 .rating(3)
                 .likeCount(30)
@@ -136,9 +143,10 @@ class ReviewRepositoryTest {
                 .user(testUser2)
                 .book(testBook1)
                 .content("Review 3 content")
-                .createdAt(LocalDateTime.now().minusDays(2))
+                .createdAt(time3)
                 .build();
         testReview3 = em.merge(testReview3);
+        forceUpdateCreatedAt(testReview3, time3);
 
         testReview4 = Review.builder()
                 .rating(2)
@@ -230,11 +238,13 @@ class ReviewRepositoryTest {
         assertThat(slice.hasNext()).isTrue();
     }
 
-    *//*@Test
+    @Test
     @DisplayName("리뷰 다건 조회 성공 - 기본 조회, 최신순 2개, 다음 페이지")
     void getReviews_cursor_createdAt_desc() {
 
         // given
+        testReview2 = reviewRepository.findById(testReview2.getId()).orElseThrow();
+
         Pageable pageable = PageRequest.ofSize(2);
         ReviewSearchCondition condition = ReviewSearchCondition.builder()
                 .cursor(testReview2.getCreatedAt().toString())
@@ -256,6 +266,8 @@ class ReviewRepositoryTest {
     void getReviews_cursor_rating_desc() {
 
         // given
+        testReview2 = reviewRepository.findById(testReview2.getId()).orElseThrow();
+
         Pageable pageable = PageRequest.ofSize(2);
         ReviewSearchCondition condition = ReviewSearchCondition.builder()
                 .useRating(true)
@@ -273,7 +285,7 @@ class ReviewRepositoryTest {
         assertThat(slice.getContent()).extracting("id")
                 .containsExactly(testReview1.getId());
         assertThat(slice.hasNext()).isFalse();
-    }*//*
+    }
 
     @Test
     @DisplayName("리뷰 다건 조회 성공 - 사용자 ID 및 도서 ID로 조회")
@@ -343,6 +355,8 @@ class ReviewRepositoryTest {
     void getPopularReviews_success_cursor_desc() {
 
         // given
+        testReview2 = reviewRepository.findById(testReview2.getId()).orElseThrow();
+
         Pageable pageable = PageRequest.ofSize(2);
         PopularReviewSearchCondition condition = PopularReviewSearchCondition.builder()
                 .period(PeriodType.ALL_TIME)
@@ -357,8 +371,16 @@ class ReviewRepositoryTest {
 
         // then
         assertThat(slice.getContent()).hasSize(1);
-//        assertThat(slice.getContent()).extracting("id")
-//                .containsExactly(testReview2.getId());
-//        assertThat(slice.hasNext()).isTrue();
-//    }*/
+        assertThat(slice.getContent()).extracting("id")
+                .containsExactly(testReview3.getId());
+        assertThat(slice.hasNext()).isFalse();
+    }
+
+    // 시간 강제 변경
+    private void forceUpdateCreatedAt(Review review, LocalDateTime time) {
+        Query query = em.createNativeQuery("UPDATE review SET created_at=?1 WHERE id=?2");
+        query.setParameter(1, time);
+        query.setParameter(2, review.getId());
+        query.executeUpdate();
+    }
 }

--- a/src/test/java/com/sprint/sb06deokhugamteam01/service/book/coverage/BasicS3StorageServiceUnitTest.java
+++ b/src/test/java/com/sprint/sb06deokhugamteam01/service/book/coverage/BasicS3StorageServiceUnitTest.java
@@ -1,0 +1,114 @@
+package com.sprint.sb06deokhugamteam01.service.book.coverage;
+
+import com.sprint.sb06deokhugamteam01.exception.book.S3ObjectNotFound;
+import com.sprint.sb06deokhugamteam01.service.book.BasicS3StorageService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
+
+import java.net.URL;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class BasicS3StorageServiceUnitTest {
+    @Mock
+    S3Client s3Client;
+    @Mock
+    S3Presigner s3Presigner;
+    @InjectMocks
+    BasicS3StorageService s3Service;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(s3Service, "bucket", "test-bucket");
+        ReflectionTestUtils.setField(s3Service, "presignedUrlExpiration", "PT10H");
+    }
+
+    @Test
+    @DisplayName("putObject 테스트 - AWS mock 처리 후 서비스 로직만 테스트")
+    void putObject() {
+        // given
+        String id = UUID.randomUUID().toString();
+        byte[] data = "data".getBytes();
+
+        // when
+        s3Service.putObject(id, data);
+
+        // then
+        verify(s3Client).putObject(any(PutObjectRequest.class), any(RequestBody.class));
+    }
+    @Test
+    @DisplayName("deleteObject 테스트 - AWS mock 처리 후 서비스 로직만 테스트")
+    void deleteObject() {
+        //given
+        String id = UUID.randomUUID().toString();
+
+        //when
+        s3Service.deleteObject(id);
+
+        //then
+        verify(s3Client).deleteObject(any(DeleteObjectRequest.class));
+    }
+
+    @Test
+    @DisplayName("s3 파일 부재로 deleteObjects 실패 - AWS mock 처리 후 서비스 로직만 테스트")
+    void deleteObjects_Failure_S3ObjectNotFound() {
+        // given
+        String id = UUID.randomUUID().toString();
+        given(s3Client.headObject(any(Consumer.class)))
+                .willThrow(NoSuchKeyException.builder().build());
+
+        // when & then
+        assertThrows(S3ObjectNotFound.class, () -> {s3Service.deleteObject(id);});
+    }
+
+    @Test
+    @DisplayName("getPresignedUrl 테스트 - AWS mock 처리 후 서비스 로직만 테스트")
+    void getPresignedUrl() throws Exception {
+        // given
+        String id = UUID.randomUUID().toString();
+        PresignedGetObjectRequest request = mock(PresignedGetObjectRequest.class);
+        given(request.url()).willReturn(new URL("http://url.com"));
+        given(s3Presigner.presignGetObject(any(GetObjectPresignRequest.class)))
+                .willReturn(request);
+
+        // when
+        String result = s3Service.getPresignedUrl(id);
+
+        // then
+        assertEquals("http://url.com", result);
+    }
+
+    @Test
+    @DisplayName("s3 파일 부재로 getPresignedUrl 실패 - AWS mock 처리 후 서비스 로직만 테스트")
+    void getPresignedUrl_Failure_S3ObjectNotFound() {
+        // given
+        String id = UUID.randomUUID().toString();
+        given(s3Client.headObject(any(Consumer.class)))
+                .willThrow(NoSuchKeyException.builder().build());
+
+        // when & then
+        assertThrows(S3ObjectNotFound.class, () -> {s3Service.getPresignedUrl(id);});
+    }
+}

--- a/src/test/java/com/sprint/sb06deokhugamteam01/service/book/coverage/NaverBookSearchServiceFailureTest.java
+++ b/src/test/java/com/sprint/sb06deokhugamteam01/service/book/coverage/NaverBookSearchServiceFailureTest.java
@@ -1,0 +1,31 @@
+package com.sprint.sb06deokhugamteam01.service.book.coverage;
+
+import com.sprint.sb06deokhugamteam01.exception.book.BookInfoFetchFailedException;
+import com.sprint.sb06deokhugamteam01.service.book.NaverBookSearchService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@SpringBootTest
+@ActiveProfiles("test")
+public class NaverBookSearchServiceFailureTest {
+
+    @Autowired
+    NaverBookSearchService naverBookSearchService;
+
+    @Test
+    @DisplayName("가짜 키로 요청할 시 도서 검색 실패")
+    void searchBookByIsbn() {
+        // given
+        String isbn = "1234567890";
+
+        // when & then
+        assertThrows(BookInfoFetchFailedException.class, () -> {
+            naverBookSearchService.searchBookByIsbn(isbn);
+        });
+    }
+}

--- a/src/test/java/com/sprint/sb06deokhugamteam01/service/comment/CommentServiceTest.java
+++ b/src/test/java/com/sprint/sb06deokhugamteam01/service/comment/CommentServiceTest.java
@@ -58,24 +58,27 @@ public class CommentServiceTest {
     @DisplayName("댓글 등록 성공")
     void createComment_Success(){
         // given
-        UUID userId = UUID.randomUUID();
+        UUID requesterId = UUID.randomUUID();
+        UUID reviewOwnerId = UUID.randomUUID();
         UUID reviewId = UUID.randomUUID();
 
-        User user = User.builder().nickname("유저").build();
-        ReflectionTestUtils.setField(user, "id", userId);
-        Review review = Review.builder().user(user).build();
+        User requester = User.builder().nickname("요청자").build();
+        ReflectionTestUtils.setField(requester, "id", requesterId);
+        User reviewOwner = User.builder().nickname("리뷰 작성자").build();
+        ReflectionTestUtils.setField(reviewOwner, "id", reviewOwnerId);
+        Review review = Review.builder().user(reviewOwner).build();
         ReflectionTestUtils.setField(review, "id", reviewId);
 
         String content = "댓글";
 
-        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(userRepository.findById(requesterId)).willReturn(Optional.of(requester));
         given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
         given(commentRepository.save(any(Comment.class)))
                 .willAnswer(invocation -> invocation.getArgument(0));
         given(notificationRepository.save(any(Notification.class)))
                 .willAnswer(invocation -> invocation.getArgument(0));
 
-        CommentCreateRequest request = new CommentCreateRequest(reviewId, userId, content);
+        CommentCreateRequest request = new CommentCreateRequest(reviewId, requesterId, content);
 
         // when
         CommentDto result = commentService.createComment(request);
@@ -84,7 +87,7 @@ public class CommentServiceTest {
         assertThat(result).isNotNull();
         assertThat(result.reviewId()).isEqualTo(reviewId);
         assertThat(result.content()).isEqualTo(content);
-        assertThat(result.userNickname()).isEqualTo("유저");
+        assertThat(result.userNickname()).isEqualTo("요청자");
         verify(commentRepository).save(any(Comment.class));
         verify(notificationRepository).save(any(Notification.class));
     }


### PR DESCRIPTION
 ### Summary
- 테스트 커버리지 61% -> 77% 로 개선 (-80%까지 개선 예정)
  - ErrorDto, PopularBookDto, PowerUserDto, CursorPageResponsePowerUserDto, BookData, NaverBookSearchResponse, PageNotificationRequest, PowerUserRequest 테스트
  - Exception 생성 테스트
  - ReviewMapper 테스트
  - ReviewRepositoryTest 주석 해제
  - NotificationRepositoryTest happy path 테스트 추가
  - NaverBookSearchService 실패 케이스 테스트 추가
  - BasicS3StorageServiceUnitTest 추가 (AWS 기능 mock, 서비스 로직만 테스트)
 
### Note
- 테스트 커버리지를 개선시키기 위해 기존 주석처리 되어 있던 ReviewRepositoryTest 주석을 풀어 실행해 보았습니다. 제 로컬 환경에서는 JPA Auditing 작동으로 테스트가 실패하는 문제가 있어, 테스트 환경에서만 강제로 과거 시간을 주입하도록 setup 로직을 조금 변경했습니다. (리포지토리 로직 변경은 없었습니다!)

---
### Change
- review.decreaseCommentCount() 로직 추가되며 댓글 물리 삭제 시 오류 발생 -> Fix
- 자신의 리뷰에 댓글을 달 경우 알림이 오지 않도록 로직 변경
=> 로컬에서 댓글 관련 기능 EtoE 테스트 진행 완료